### PR TITLE
Added ability to output report to 'filePath' using 'intercept-stdout'

### DIFF
--- a/lib/intercept-stdout.js
+++ b/lib/intercept-stdout.js
@@ -1,0 +1,41 @@
+// This file is from a gist written by Ben Buckman
+// Many thanks Ben!
+// https://gist.github.com/benbuckman/2758563/
+var _ = require('underscore'),
+    util = require('util');
+
+// intercept stdout, passes thru callback
+// also pass console.error thru stdout so it goes to callback too
+// (stdout.write and stderr.write are both refs to the same stream.write function)
+// returns an unhook() function, call when done intercepting
+module.exports = function interceptStdout(callback) {
+  var old_stdout_write = process.stdout.write,
+      old_console_error = console.error;
+
+  process.stdout.write = (function(write) {
+    return function(string, encoding, fd) {
+      var args = _.toArray(arguments);
+      write.apply(process.stdout, args);
+
+      // only intercept the string
+      callback.call(callback, string);
+    };
+  }(process.stdout.write));
+
+  console.error = (function(log) {
+    return function() {
+      var args = _.toArray(arguments);
+      args.unshift('[ERROR]');
+      console.log.apply(console.log, args);
+
+      // string here encapsulates all the args
+      callback.call(callback, util.format(args));
+    };
+  }(console.error));
+
+  // puts back to original
+  return function unhook() {
+    process.stdout.write = old_stdout_write;
+    console.error = old_console_error;
+  };
+};

--- a/lib/reporter-file.js
+++ b/lib/reporter-file.js
@@ -1,7 +1,6 @@
 
 var mocha = require('mocha'),
     fs = require('fs'),
-    js2xml = require('js2xmlparser'),
 
     config = require('../config'),
 
@@ -9,74 +8,30 @@ var mocha = require('mocha'),
 
     reporterName = process.env.MOCHA_REPORTER || config.reporter || 'XUnit',
     Reporter = mocha.reporters[reporterName],
-
     filePath = process.env.MOCHA_REPORTER_FILE || config.file || process.cwd() + "/xunit.xml";
-
-
 
 function ReporterFile(runner) {
 
-    Reporter.call(this, runner);
-
-    var stats = this.stats,
-        tests = [];
-
-    runner.on('test', function(test){
-        tests.push(test);
+    // Hijack stdout.write() before calling the Reporter
+    // This will override mocha's internal calls to process.stdout.write() so
+    // that it uses fs.writeFile() instead, allowing us to make Mocha write to
+    // the file we set as MOCHA_REPORTER_FILE
+    var unhookStdout = require('./intercept-stdout.js')(function intercept(string){
+        fs.writeFile(filePath, string);
     });
 
+    Reporter.call(this, runner);
+
     runner.on('end', function(){
-
-        var data = {
-                '@': {
-                    name: 'Mocha Tests',
-                    tests: stats.tests,
-                    failures: stats.failures,
-                    errors: stats.failures,
-                    skipped: stats.tests - stats.failures - stats.passes,
-                    timestamp: (new Date).toUTCString(),
-                    time: stats.duration / 1000
-                },
-                'testcase': tests.map(function (test) {
-                    var data = {
-                        '@': {
-                            classname: test.parent.fullTitle(),
-                            name: test.title,
-                            time: test.duration ? test.duration / 1000 : 0
-                        }
-                    };
-
-                    if (test.state === 'failed') {
-                        data.failure = {
-                            '@': {
-                                message: test.err.message
-                            },
-                            '#': test.err.stack
-                        }
-                    } else if (test.state === 'pending') {
-                        delete data['@'].time;
-                        data.skipped = '';
-                    }
-
-                    return data;
-                })
-            },
-
-            output = js2xml('testsuite', data) + '\n',
-
-            writeErr = fs.writeFileSync(filePath, output);
-
-            if (writeErr) {
-                throw writeErr;
-            }
-
-            console.log('> Report was written to: ' + filePath + '\n');
-
+        // Release process.stdout.write() so that any more calls to it in the
+        // current process work normally again
+        unhookStdout();
+        // See how this console.log outputs back to the terminal
+        console.log('> Report was written to: ' + filePath + '\n');
     });
 }
 
 // Inherit from the specified reporter
 ReporterFile.prototype = Reporter.prototype;
-
 
 module.exports = ReporterFile;


### PR DESCRIPTION
Because of issue #1, I was unable to use this plugin the way I wanted. By including a script from [this gist](https://gist.github.com/benbuckman/2758563/) I was able to alter the plugin to highjack `stdout.write()` and replace it with `fs.writeFile()`. This allows the plugin to write to `filePath` instead of always writing out the XML output. I also removed any of the XML parsing that was being done, because this method allows Mocha's reporters to do all the heavy lifting.
## Commit info
- Added 'intercept-stdout' gist from Ben Buckman
- Changed plugin to higjack stdout.write() before calling the mocha reporter
- This allows mocha's Reporter do all of the work, and this plugin just hijacks stdout.write() so that mocha's reporter automatically writes to the file named in 'filePath'
- Removed dependency on 'js2xmlparser' because mocha is already doing all the parsing we need
