### PR TITLE
(fix) Fixed no output bug.

### DIFF
--- a/lib/reporter-file.js
+++ b/lib/reporter-file.js
@@ -16,7 +16,7 @@ function ReporterFile(runner) {
     // that it uses fs.writeFile() instead, allowing us to make Mocha write to
     // the file we set as MOCHA_REPORTER_FILE
     var unhookStdout = require('intercept-stdout')(function intercept(string){
-        fs.writeFile(filePath, string);
+        fs.writeFileSync(filePath, string);
     });
 
     Reporter.call(this, runner);


### PR DESCRIPTION
When running mocha in nodejs via `child_process.exec` the output file is not
created. This seems to happen, because the process exits before the file is written.
I used `writeFileSync` to ensure that the file has been written before continuing.
